### PR TITLE
Tweak SI test data to cope with EBL changes

### DIFF
--- a/src/test/java/org/dcsa/api_validator/ebl/v1/shippinginstructions/PostShippingInstructionsTest.java
+++ b/src/test/java/org/dcsa/api_validator/ebl/v1/shippinginstructions/PostShippingInstructionsTest.java
@@ -91,7 +91,6 @@ public class PostShippingInstructionsTest {
 //                        "  \"tareWeight\": \"MISSING\",\n" +
 //                        "  \"clauseContent\": \"MISSING\",\n" +
 //                        "  \"carrierCode\": \"MISSING\",\n" +
-//                        "  \"verifiedGrossMass\": \"MISSING\",\n" +
 //                        "  \"declaredValue\": 0,\n" +
 //                        "  \"declaredValueCurrencyCode\": \"MISSING\",\n" +
 //                        "  \"shippingMarks\": \"MISSING\",\n" +

--- a/src/test/resources/ebl/v1/shipping-instructions/basic-valid-shipping-instructions.json
+++ b/src/test/resources/ebl/v1/shipping-instructions/basic-valid-shipping-instructions.json
@@ -25,7 +25,9 @@
   ],
   "shipmentEquipments": [
     {
-      "equipmentReference": "BMOU2149612",
+      "equipment": {
+        "equipmentReference": "BMOU2149612"
+      },
       "cargoGrossWeight": 12000,
       "cargoGrossWeightUnit": "KGM",
       "seals": [


### PR DESCRIPTION
Signed-off-by: Niels Thykier <nt@asseco.dk>