### PR TITLE
Temporarily reduce the party details in SI

### DIFF
--- a/src/test/resources/ebl/v1/shipping-instructions/basic-valid-shipping-instructions.json
+++ b/src/test/resources/ebl/v1/shipping-instructions/basic-valid-shipping-instructions.json
@@ -46,14 +46,7 @@
     {
       "party": {
         "partyName": "Digital Container Shipping Association",
-        "publicKey": "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6IkFzaW",
-        "streetName": "Strawinskylaan",
-        "streetNumber": "4117",
-        "floor": "4th Floor",
-        "postalCode": "1077",
-        "cityName": "ZX Amsterdam",
-        "stateRegion": "N/A",
-        "country": "Netherlands"
+        "publicKey": "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6IkFzaW"
       },
       "partyFunction": "CN",
       "displayedAddress": "Soelvgade 12",


### PR DESCRIPTION
This will make the test succeed even when the Address entity is separated from the Party entity.  Once that move is complete, we will put the data back (in its new location)