### PR TITLE
Remove attributes in basic test SI temporarily

### DIFF
--- a/src/test/resources/ebl/v1/shipping-instructions/basic-valid-shipping-instructions.json
+++ b/src/test/resources/ebl/v1/shipping-instructions/basic-valid-shipping-instructions.json
@@ -59,8 +59,6 @@
         "publicKey": "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6IkFzaW"
       },
       "partyFunction": "CN",
-      "displayedAddress": "Soelvgade 12",
-      "partyContactDetails": "+45 12345678",
       "shouldBeNotified": false
     }
   ],


### PR DESCRIPTION
This avoid/breaks a circular dependency between EBL and API validator
for rewriting the party contact details + displayed address
attributes.

Signed-off-by: Niels Thykier <nt@asseco.dk>