### PR TITLE
Correct TNT test to use a list for eventType

### DIFF
--- a/src/test/java/org/dcsa/api_validator/tnt/v2/EventSubscriptionsTest.java
+++ b/src/test/java/org/dcsa/api_validator/tnt/v2/EventSubscriptionsTest.java
@@ -120,7 +120,7 @@ public class EventSubscriptionsTest {
                 contentType("application/json").
                 body("{\n" +
                         "  \"callbackUrl\": \""+Configuration.CALLBACK_URI+"/receive-transport-events\",\n" +
-                        "  \"eventType\": \"TRANSPORT\"," +
+                        "  \"eventType\": [\"TRANSPORT\"]," +
                         "  \"bookingReference\": \"\",\n" +
                         "  \"transportDocumentID\": \"\",\n" +
                         "  \"transportDocumentType\": \"\",\n" +


### PR DESCRIPTION
This happens to work because TNT `@JsonIgnore`s the field, which is a separate problem.  But since the field is ignored, we can fix the test now.