### PR TITLE
Fix/adjust invoice payable at field

### DIFF
--- a/src/test/resources/ebl/v1/ShippingInstructionsSchema.json
+++ b/src/test/resources/ebl/v1/ShippingInstructionsSchema.json
@@ -25,7 +25,7 @@
           "volume",
           "weightUnit",
           "volumeUnit",
-          "freightPayableAt",
+          "invoicePayableAt",
           "dateOfIssue",
           "equipmentReference",
           "ISOEquipmentCode",
@@ -183,10 +183,10 @@
             "type": "string",
             "title": "The volumeUnit schema"
           },
-          "freightPayableAt": {
-            "id": "#/items/anyOf/0/properties/freightPayableAt",
+          "invoicePayableAt": {
+            "id": "#/items/anyOf/0/properties/invoicePayableAt",
             "type": "string",
-            "title": "The freightPayableAt schema"
+            "title": "The invoicePayableAt schema"
           },
           "dateOfIssue": {
             "id": "#/items/anyOf/0/properties/dateOfIssue",

--- a/src/test/resources/ebl/v1/shipping-instructions/basic-valid-shipping-instructions.json
+++ b/src/test/resources/ebl/v1/shipping-instructions/basic-valid-shipping-instructions.json
@@ -6,7 +6,7 @@
   "isShippedOnBoardType": true,
   "transportDocumentType": "SWB",
   "invoicePayableAt": {
-    "UNLocationCode": "USNYC",
+    "UNLocationCode": "DKCPH",
     "address": {
       "cityName": "København",
       "stateRegion": "N/A",

--- a/src/test/resources/ebl/v1/shipping-instructions/basic-valid-shipping-instructions.json
+++ b/src/test/resources/ebl/v1/shipping-instructions/basic-valid-shipping-instructions.json
@@ -5,8 +5,13 @@
   "isElectronic": true,
   "isShippedOnBoardType": true,
   "transportDocumentType": "SWB",
-  "freightPayableAt": {
-    "locationName": "Port of Rotterdam"
+  "invoicePayableAt": {
+    "UNLocationCode": "USNYC",
+    "address": {
+      "cityName": "København",
+      "stateRegion": "N/A",
+      "country": "Denmark"
+    }
   },
   "cargoItems": [
     {


### PR DESCRIPTION
As I was trying to validate my API implementation via the validator, I was constantly failing the test to create simple shipping-instructions since the freightPayableAt field was not yet replaced by the invoicePayableAt field.

As far as I understand the code, this should be now done.