### PR TITLE
Add missing utilizedTransportEquipment/equipment/isShipperOwned field

### DIFF
--- a/src/test/resources/ebl/v1/ShippingInstructionsSchema.json
+++ b/src/test/resources/ebl/v1/ShippingInstructionsSchema.json
@@ -28,6 +28,7 @@
           "invoicePayableAt",
           "dateOfIssue",
           "equipmentReference",
+          "isShipperOwned",
           "ISOEquipmentCode",
           "paymentTerm",
           "shipmentEquipmentQuantity"
@@ -197,6 +198,11 @@
             "id": "#/items/anyOf/0/properties/equipmentReference",
             "type": "string",
             "title": "The equipmentReference schema"
+          },
+          "isShipperOwned": {
+            "id": "#/items/anyOf/0/properties/isShipperOwned",
+            "type": "boolean",
+            "title": "Indicates whether the container is shipper owned (SOC)."
           },
           "ISOEquipmentCode": {
             "id": "#/items/anyOf/0/properties/ISOEquipmentCode",

--- a/src/test/resources/ebl/v1/shipping-instructions/basic-valid-shipping-instructions.json
+++ b/src/test/resources/ebl/v1/shipping-instructions/basic-valid-shipping-instructions.json
@@ -32,10 +32,11 @@
       "equipmentReference": "BMOU2149612"
     }
   ],
-  "shipmentEquipments": [
+  "utilizedTransportEquipments": [
     {
       "equipment": {
-        "equipmentReference": "BMOU2149612"
+        "equipmentReference": "BMOU2149612",
+        "isShipperOwned": true
       },
       "cargoGrossWeight": 12000,
       "cargoGrossWeightUnit": "KGM",
@@ -56,8 +57,8 @@
           "street": "Strawinskylaan",
           "streetNumber": "4117",
           "floor": "4th Floor",
-          "postalCode": "1077",
-          "cityName": "ZX Amsterdam",
+          "postCode": "1077",
+          "city": "ZX Amsterdam",
           "stateRegion": "N/A",
           "country": "Netherlands"
         },

--- a/src/test/resources/ebl/v1/shipping-instructions/basic-valid-shipping-instructions.json
+++ b/src/test/resources/ebl/v1/shipping-instructions/basic-valid-shipping-instructions.json
@@ -25,6 +25,7 @@
       "descriptionOfGoods": "Leather sheets",
       "HSCode": "411510",
       "numberOfPackages": 18,
+      "packageCode": "5H",
       "weight": 13000.3,
       "volume": 12,
       "weightUnit": "KGM",


### PR DESCRIPTION
The shippingEquipment field was changed to the utilizedTransportEquipment field and got a new required boolean field utilizedTransportEquipment/equipment/isShipperOwned.