### PR TITLE
Update publisher publisher role in timestamps

### DIFF
--- a/src/test/resources/ovs/v2/ovsTimeStamps/TimeStampsSample.json
+++ b/src/test/resources/ovs/v2/ovsTimeStamps/TimeStampsSample.json
@@ -16,7 +16,7 @@
     },
     "nmftaCode": "MMCU"
   },
-  "publisherRole": "ATH",
+  "publisherRole": "CA",
   "vesselIMONumber": "9321483",
   "UNLocationCode": "USNYC",
   "facilitySMDGCode": "APMT",

--- a/src/test/resources/ovs/v2/ovsTimeStamps/TimeStampsSample.json
+++ b/src/test/resources/ovs/v2/ovsTimeStamps/TimeStampsSample.json
@@ -16,7 +16,7 @@
     },
     "nmftaCode": "MMCU"
   },
-  "publisherRole": "DDS",
+  "publisherRole": "ATH",
   "vesselIMONumber": "9321483",
   "UNLocationCode": "USNYC",
   "facilitySMDGCode": "APMT",


### PR DESCRIPTION
This is because we have changed `PublisherRole` from a `String` to an `enum` class.