### PR TITLE
Enabling optional Timestamp fields tests

### DIFF
--- a/src/test/java/org/dcsa/api_validator/ovs/v2/PostTimestampsTest.java
+++ b/src/test/java/org/dcsa/api_validator/ovs/v2/PostTimestampsTest.java
@@ -60,7 +60,7 @@ public class PostTimestampsTest {
 
 
     // Testing with mandatory fields + FacilitySMDGCode field
-    @Test
+    @Test(enabled = false)
     public void testFacilitySMDGCodeField() {
 
         Map<String, String> map = (Map<String, String>) jsonToMap(VALID_TIMESTAMP);
@@ -210,7 +210,7 @@ public class PostTimestampsTest {
     }
 
     // Testing with mandatory fields + ModeOfTransport field
-    @Test
+    @Test(enabled = false)
     public void testModeOfTransportField() {
 
         Map<String, String> map = (Map<String, String>) jsonToMap(VALID_TIMESTAMP);
@@ -267,7 +267,7 @@ public class PostTimestampsTest {
     }
 
     // Testing with mandatory fields + PortCallServiceTypeCode field
-    @Test
+    @Test(enabled = false)
     public void testPortCallServiceTypeCodeField() {
 
         Map<String, String> map = (Map<String, String>) jsonToMap(VALID_TIMESTAMP);

--- a/src/test/java/org/dcsa/api_validator/ovs/v2/PostTimestampsTest.java
+++ b/src/test/java/org/dcsa/api_validator/ovs/v2/PostTimestampsTest.java
@@ -60,7 +60,7 @@ public class PostTimestampsTest {
 
 
     // Testing with mandatory fields + FacilitySMDGCode field
-    @Test(enabled = false)
+    @Test
     public void testFacilitySMDGCodeField() {
 
         Map<String, String> map = (Map<String, String>) jsonToMap(VALID_TIMESTAMP);
@@ -106,7 +106,7 @@ public class PostTimestampsTest {
     }
 
     // Testing with mandatory fields + EventLocation field
-    @Test(enabled = false)
+    @Test
     public void testEventLocationField() {
 
         Map<String, String> map = (Map<String, String>) jsonToMap(VALID_TIMESTAMP);
@@ -153,7 +153,7 @@ public class PostTimestampsTest {
     }
 
     // Testing with mandatory fields + VesselPosition field
-    @Test(enabled = false)
+    @Test
     public void testVesselPositionField() {
 
         Map<String, String> map = (Map<String, String>) jsonToMap(VALID_TIMESTAMP);
@@ -210,7 +210,7 @@ public class PostTimestampsTest {
     }
 
     // Testing with mandatory fields + ModeOfTransport field
-    @Test(enabled = false)
+    @Test
     public void testModeOfTransportField() {
 
         Map<String, String> map = (Map<String, String>) jsonToMap(VALID_TIMESTAMP);
@@ -267,7 +267,7 @@ public class PostTimestampsTest {
     }
 
     // Testing with mandatory fields + PortCallServiceTypeCode field
-    @Test(enabled = false)
+    @Test
     public void testPortCallServiceTypeCodeField() {
 
         Map<String, String> map = (Map<String, String>) jsonToMap(VALID_TIMESTAMP);

--- a/src/test/resources/ovs/v2/EventsSchema.json
+++ b/src/test/resources/ovs/v2/EventsSchema.json
@@ -155,7 +155,7 @@
             "vesselCallSignNumber": {
               "id": "#/transportCall/properties/vessel/properties/vesselCallSignNumber",
               "description": "A unique alphanumeric identity that belongs to the vessel and is assigned by the International Telecommunication Union (ITU).",
-              "type": "string",
+              "type": ["string","null"],
               "default": "",
               "maxLength": 10
             },

--- a/src/test/resources/ovs/v2/ovsTimeStamps/TimeStampsSample.json
+++ b/src/test/resources/ovs/v2/ovsTimeStamps/TimeStampsSample.json
@@ -45,5 +45,10 @@
   },
   "modeOfTransport": "VESSEL",
   "portCallServiceTypeCode": "BUNK",
-  "eventDateTime": "2019-11-12T07:41:00+08:30"
+  "eventDateTime": "2019-11-12T07:41:00+08:30",
+  "carrierVoyageNumber": "2103S",
+  "carrierServiceCode": "FE1",
+  "transportCallSequenceNumber": 2,
+  "remark": "Port closed due to strike",
+  "delayReasonCode": "WEA"
 }


### PR DESCRIPTION
This is done to test against PR#46 --- Ensure that Timestamp doesn't fail on null on optional properties [#46](https://github.com/dcsaorg/DCSA-OVS/pull/46) ---

- testPortCallServiceTypeCodeField
- testModeOfTransportField
- testVesselPositionField
- testEventLocationField
- testEventLocationField
- testFacilitySMDGCodeField

- fix added to schema to allow nulling of vesselCallSignNumber. 

Note: This not expected to pass the test on OVS master